### PR TITLE
Class name fix

### DIFF
--- a/example.apollo.py
+++ b/example.apollo.py
@@ -1,5 +1,5 @@
 import json
-from olipy.queneau import DialogueAssembler
+from queneau import DialogueAssembler
 
 d = DialogueAssembler.loadlines(open("data/apollo_11.txt"))
 last_speaker = None


### PR DESCRIPTION
One of these examples is not like the others!

> Traceback (most recent call last):
>   File "example.apollo.py", line 2, in <module>
>     from olipy.queneau import DialogueAssembler
> ImportError: No module named olipy.queneau

Over.
