### PR TITLE
Checking link sources in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ corpora.get_file("words/literature", "shakespeare_words")
 ## ebooks.py
 
 A module for incongruously sampling texts in the style of the infamous
-[https://twitter.com/horse_ebooks](@horse_ebooks). Based on the
-[https://twitter.com/zzt_ebooks](@zzt_ebooks) algorithm by Allison
+ [@horse_ebooks] (https://twitter.com/horse_ebooks). Based on the
+[zzt_ebooks] (https://twitter.com/zzt_ebooks) algorithm by Allison
 Parrish.
 
 ```


### PR DESCRIPTION
Thanks for uploading this. I've been playing with it and learning by reading the link sources.
Fixed inline links were swapped for horse_ebooks and zzt_ebooks.
FYI-- The Freli link is down . http://www.nkuitse.com/freli/
The Apollo flight journal link  http://history.nasa.gov/ap11fj/ is broken, perhaps you meant https://history.nasa.gov/afj/ap11fj/index.html